### PR TITLE
generate an online book-like website from the notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: rust
+script:
+  - rev=$(git rev-parse --short HEAD)
+  - (cargo install mdbook --vers 0.0.26 --force || true)
+  - ./generate-book.sh
+
+branches:
+  only:
+    - master
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: ./book/
+  on:
+    branch: master

--- a/generate-book.sh
+++ b/generate-book.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -d src ]; then
+  mkdir src
+fi
+
+echo "[Introduction](introduction.md)" > src/SUMMARY.md
+
+
+for category in docs-team ember-cli ember-data ember.js fastboot-team
+do
+  if [ ! -d src/$category ]; then
+    mkdir src/$category
+  fi
+  echo "- [$category]($category/README.md)" >> src/SUMMARY.md
+  echo "# $category" >> $category/README.md
+
+  for file in `ls $category/*/*.md | sort -r`
+  do
+    year_month=$(echo $(dirname $file) | cut -d'/' -f2)
+    year=$(echo $year_month | cut -d'-' -f1)
+    month=$(echo $year_month | cut -d'-' -f2)
+
+    filename=$(basename $file ".md")
+    day=$(echo $filename | cut -d'-' -f2)
+
+    title=$year-$month-$day
+
+    echo "    - [$category-$title]($category/$title.md)" >> src/SUMMARY.md
+    cp $file src/$category/$title.md
+  done
+done
+
+cp README.md src/introduction.md
+
+mdbook build


### PR DESCRIPTION
This is an attempt at building a static gitbook like version of the notes. It aims at doing something similar to Ember RFC's website https://emberjs.github.io/rfcs/

Here is a demo of the end result: http://ember-core-notes-demo.surge.sh/

If we are ok with this, can we create a travis build to deploy it on github pages?