### PR TITLE
Create framework notes for September 9th

### DIFF
--- a/ember.js/2022-09/Sep 09 2022.md
+++ b/ember.js/2022-09/Sep 09 2022.md
@@ -1,0 +1,22 @@
+# September 09, 2022
+
+## Attendees
+
+- Ed Faulkner
+- Katie Gengler
+- Godfrey Chan
+- Melanie Sumner
+- Ricardo Mendes
+
+## Agenda
+
+- (public) FCP → merge
+    - [RFC 847](https://github.com/emberjs/rfcs/pull/847)
+    - [RFC 790](https://github.com/emberjs/rfcs/pull/790)
+    - [RFC 814](https://github.com/emberjs/rfcs/pull/814)
+- (public) RFC to FCP
+    - [RFC 848](https://github.com/emberjs/rfcs/pull/848)
+- (public) FCP to close → Close
+    - [RFC 519](https://github.com/emberjs/rfcs/pull/512)
+- (public) Issues with tutorial not building
+- (public) Review other RFCs (sorting by "recently updated" and go through the list as time allows


### PR DESCRIPTION
If merged, this PR adds notes from the framework core team meeting on September 9, 2022.