### PR TITLE
Update learning-team links to review pull requests under `ember-learn` using fancy GH Search

### DIFF
--- a/learning-team/template.md
+++ b/learning-team/template.md
@@ -22,11 +22,9 @@ Add yourself to the list if you attend and check the box!
 
 ## Weekly review
 
-[Open pull requests](https://help-wanted.emberjs.com/pull-requests)
-
-[RFC review app](https://rfcs.emberjs.com/)
-
-[RFC PR Queue](https://github.com/emberjs/rfcs/pulls)
+Open pull requests
+- [Approved PRs](https://github.com/search?q=org%3Aember-learn+review%3Aapproved+is%3Aopen+draft%3Afalse&type=pullrequests)
+- [Need Review](https://github.com/search?q=org%3Aember-learn++is%3Aopen+draft%3Afalse+-author%3Aapp%2Fdependabot+-review%3Aapproved&type=pullrequests&s=created&o=desc)
 
 ## Topics
 


### PR DESCRIPTION
Preview 'em here:

Approved: https://github.com/search?q=org%3Aember-learn+review%3Aapproved+is%3Aopen+draft%3Afalse&type=pullrequests
Need Review: https://github.com/search?q=org%3Aember-learn++is%3Aopen+draft%3Afalse+-author%3Aapp%2Fdependabot+-review%3Aapproved&type=pullrequests&s=created&o=desc